### PR TITLE
Add jvm, js and wasmJs targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ## Integration
 
-### Android
+### Gradle (JVM, Android, KMP)
 
 Add this to your dependencies:
 
-`implementation 'io.stepuplabs.spaydkmp:spayd-kmp-android:<latest-version>'`
+`implementation 'io.stepuplabs.spaydkmp:spayd-kmp:<latest-version>'`
 
 ### iOS
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ kotlinx-datetime = "0.6.1"
 ktor = "3.0.0"
 okio = "3.9.1"
 skie = "0.9.3"
-urlencoder = "1.4.0"
+urlencoder = "1.6.0"
 maven-deployer = "0.16.0"
 
 [plugins]

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -88,8 +88,7 @@ skie {
 
 deployer {
     content {
-        androidComponents("release") {
-            kotlinSources()
+        kotlinComponents {
             emptyDocs()
         }
     }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -3,6 +3,7 @@ import co.touchlab.skie.configuration.SealedInterop
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -31,6 +32,20 @@ kotlin {
 
             xcf.add(this)
         }
+    }
+
+    jvm()
+
+    js {
+        browser()
+        nodejs()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+        nodejs()
+        d8()
     }
 
     sourceSets {

--- a/shared/src/commonMain/kotlin/io/stepuplabs/spaydkmp/formatter/Buffer.kt
+++ b/shared/src/commonMain/kotlin/io/stepuplabs/spaydkmp/formatter/Buffer.kt
@@ -27,16 +27,8 @@ abstract class Buffer internal constructor(capacity: Int) {
         this.capacity = limit
     }
 
-    fun capacity(): Int {
-        return capacity
-    }
-
     fun hasRemaining(): Boolean {
         return position < limit
-    }
-
-    fun limit(): Int {
-        return limit
     }
 
     fun limit(newLimit: Int): Buffer {
@@ -49,10 +41,6 @@ abstract class Buffer internal constructor(capacity: Int) {
             mark = UNSET_MARK
         }
         return this
-    }
-
-    fun position(): Int {
-        return position
     }
 
     fun position(newPosition: Int): Buffer {

--- a/shared/src/commonMain/kotlin/io/stepuplabs/spaydkmp/formatter/CharArrayBuffer.kt
+++ b/shared/src/commonMain/kotlin/io/stepuplabs/spaydkmp/formatter/CharArrayBuffer.kt
@@ -81,9 +81,9 @@ class CharArrayBuffer : Buffer {
     }
 
     private fun copy(other: CharArrayBuffer, markOfOther: Int): CharArrayBuffer {
-        val buf = CharArrayBuffer(other.capacity(), other.backingArray, other.offset)
-        buf.limit = other.limit()
-        buf.position = other.position()
+        val buf = CharArrayBuffer(other.capacity, other.backingArray, other.offset)
+        buf.limit = other.limit
+        buf.position = other.position
         buf.mark = markOfOther
 
         return buf

--- a/shared/src/commonMain/kotlin/io/stepuplabs/spaydkmp/formatter/ParserStateMachine.kt
+++ b/shared/src/commonMain/kotlin/io/stepuplabs/spaydkmp/formatter/ParserStateMachine.kt
@@ -21,7 +21,7 @@ class ParserStateMachine(
     val nextFormatToken: FormatToken
         get() {
             token = FormatToken()
-            token!!.formatStringStartIndex = format.position()
+            token!!.formatStringStartIndex = format.position
 
             while (true) {
                 if (EXIT_STATE != state) {
@@ -82,7 +82,7 @@ class ParserStateMachine(
         }
     private val formatString: String
         get() {
-            val end: Int = format.position()
+            val end: Int = format.position
             format.rewind()
             val formatString: String = format.subSequence(
                 token!!.formatStringStartIndex, end
@@ -108,7 +108,7 @@ class ParserStateMachine(
 
     private fun processStartConversionState() {
         if (currentChar.isDigit()) {
-            val position: Int = format.position() - 1
+            val position: Int = format.position - 1
             val number = parseInt(format)
             var nextChar = 0.toChar()
             if (format.hasRemaining()) {
@@ -130,7 +130,7 @@ class ParserStateMachine(
                 } else { // the digital sequence stands for the width.
                     state = WIDTH_STATE
                     // do not get the next char.
-                    format.position(format.position() - 1)
+                    format.position(format.position - 1)
                     token!!.width = number
                 }
             }
@@ -140,7 +140,7 @@ class ParserStateMachine(
             token!!.argIndex = FormatToken.LAST_ARGUMENT_INDEX
         } else {
             state = FLAGS_STATE
-            format.position(format.position() - 1)
+            format.position(format.position - 1)
         }
     }
 
@@ -154,7 +154,7 @@ class ParserStateMachine(
             state = PRECISION_STATE
         } else {
             state = CONVERSION_TYPE_STATE
-            format.position(format.position() - 1)
+            format.position(format.position - 1)
         }
     }
 
@@ -164,7 +164,7 @@ class ParserStateMachine(
         } else {
             state = CONVERSION_TYPE_STATE
             // do not get the next char.
-            format.position(format.position() - 1)
+            format.position(format.position - 1)
         }
     }
 
@@ -196,12 +196,12 @@ class ParserStateMachine(
     }
 
     private fun parseInt(buffer: CharArrayBuffer): Int {
-        val start: Int = buffer.position() - 1
-        var end: Int = buffer.limit()
+        val start: Int = buffer.position - 1
+        var end: Int = buffer.limit
 
         while (buffer.hasRemaining()) {
             if (!buffer.get().isDigit()) {
-                end = buffer.position() - 1
+                end = buffer.position - 1
                 break
             }
         }


### PR DESCRIPTION
Extends KMP support to JVM, JS, and JS WASM targets, closes #2 

- `urlencoder:1.6.0` dependency is upgraded because it adds more KMP targets
- Changes in `Buffer`, `CharArrayBuffer`, and `ParserStateMachine` are made because of the signature clash on the JS platform.